### PR TITLE
fix(mmfakebench): corriger normalize() + supprimer téléchargement images + validation URL

### DIFF
--- a/src/extractors/fakeddit.py
+++ b/src/extractors/fakeddit.py
@@ -10,9 +10,8 @@ from typing import Iterator
 
 import pandas as pd
 
-from config import FAKEDDIT_RAW_DIR, IMAGES_DIR
+from config import FAKEDDIT_RAW_DIR
 from src.extractors.base import BaseExtractor
-from src.utils.image import download_image
 
 _LABEL_MAP = {0: "fake", 1: "real"}
 
@@ -56,12 +55,6 @@ class FakedditExtractor(BaseExtractor):
         label = _LABEL_MAP.get(int(raw_label), "unknown") if not pd.isna(raw_label) else "unknown"
 
         entry_id = str(raw.get("id", uuid.uuid4()))
-        image_path = IMAGES_DIR / "fakeddit" / f"{entry_id}.jpg"
-
-        success = download_image(str(image_url), image_path)
-        if not success:
-            self.logger.debug("Image inaccessible, entrée ignorée : %s", image_url)
-            return None
 
         permalink = raw.get("permalink", "")
         url = f"https://reddit.com{permalink}" if permalink else ""
@@ -74,7 +67,7 @@ class FakedditExtractor(BaseExtractor):
             "title": text,
             "text": text,
             "image_url": str(image_url),
-            "image_path": str(image_path),
+            "image_path": "",
             "label": label,
             "label_confidence": "high",
             "language": "en",

--- a/src/extractors/fakeddit.py
+++ b/src/extractors/fakeddit.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 from config import FAKEDDIT_RAW_DIR
 from src.extractors.base import BaseExtractor
+from src.utils.image import is_valid_image_url
 
 _LABEL_MAP = {0: "fake", 1: "real"}
 
@@ -44,7 +45,7 @@ class FakedditExtractor(BaseExtractor):
         text = str(raw.get("title", "")).strip()
         raw_label = raw.get("2_way_label")
 
-        if not text or not image_url or pd.isna(image_url) or str(image_url).strip() == "":
+        if not text or not is_valid_image_url(str(image_url) if not pd.isna(image_url) else ""):
             return None
 
         # Label : 0 = fake, 1 = real ; exclure non-verifiable (label 6 classes)

--- a/src/extractors/hemt_fake.py
+++ b/src/extractors/hemt_fake.py
@@ -13,9 +13,8 @@ from urllib.parse import urlparse
 
 import requests
 
-from config import IMAGES_DIR, RAW_DIR
+from config import RAW_DIR
 from src.extractors.base import BaseExtractor
-from src.utils.image import download_image
 
 _ZENODO_URL = "https://zenodo.org/records/11408513/files/HEMT-Fake.zip?download=1"
 _RAW_PATH = RAW_DIR / "hemt_fake" / "HEMT-Fake.zip"
@@ -91,13 +90,6 @@ class HemtFakeExtractor(BaseExtractor):
             label = "unknown"
 
         entry_id = str(raw.get("id") or uuid.uuid4())
-        image_path = IMAGES_DIR / "hemt_fake" / f"{entry_id}.jpg"
-
-        success = download_image(image_url, image_path)
-        if not success:
-            self.logger.debug("Image inaccessible, entrée ignorée : %s", image_url)
-            return None
-
         domain = urlparse(source_url).netloc if source_url else ""
 
         return {
@@ -106,7 +98,7 @@ class HemtFakeExtractor(BaseExtractor):
             "title": title,
             "text": text,
             "image_url": image_url,
-            "image_path": str(image_path),
+            "image_path": "",
             "label": label,
             "label_confidence": "high",
             "language": language,

--- a/src/extractors/hemt_fake.py
+++ b/src/extractors/hemt_fake.py
@@ -15,6 +15,7 @@ import requests
 
 from config import RAW_DIR
 from src.extractors.base import BaseExtractor
+from src.utils.image import is_valid_image_url
 
 _ZENODO_URL = "https://zenodo.org/records/11408513/files/HEMT-Fake.zip?download=1"
 _RAW_PATH = RAW_DIR / "hemt_fake" / "HEMT-Fake.zip"
@@ -79,7 +80,7 @@ class HemtFakeExtractor(BaseExtractor):
         language = str(raw.get("language") or "en").lower()
         source_url = str(raw.get("source_url") or raw.get("url") or "")
 
-        if not text or not image_url:
+        if not text or not is_valid_image_url(image_url):
             return None
 
         if label_raw in ("real", "true", "1"):

--- a/src/extractors/mediaeval.py
+++ b/src/extractors/mediaeval.py
@@ -11,9 +11,8 @@ from urllib.parse import urlparse
 
 import requests
 
-from config import IMAGES_DIR, RAW_DIR
+from config import RAW_DIR
 from src.extractors.base import BaseExtractor
-from src.utils.image import download_image
 
 # Archives disponibles : ajuster selon l'édition souhaitée
 _MEDIAEVAL_URLS = [
@@ -85,13 +84,6 @@ class MediaEvalExtractor(BaseExtractor):
         label = _LABEL_MAP.get(label_raw, "unknown")
 
         entry_id = tweet_id if tweet_id else str(uuid.uuid4())
-        image_path = IMAGES_DIR / "mediaeval" / f"{entry_id}.jpg"
-
-        success = download_image(image_url, image_path)
-        if not success:
-            self.logger.debug("Image inaccessible, entrée ignorée : %s", image_url)
-            return None
-
         url = f"https://twitter.com/i/web/status/{tweet_id}" if tweet_id else ""
 
         return {
@@ -100,7 +92,7 @@ class MediaEvalExtractor(BaseExtractor):
             "title": "",
             "text": text,
             "image_url": image_url,
-            "image_path": str(image_path),
+            "image_path": "",
             "label": label,
             "label_confidence": "high",
             "language": "en",

--- a/src/extractors/mediaeval.py
+++ b/src/extractors/mediaeval.py
@@ -13,6 +13,7 @@ import requests
 
 from config import RAW_DIR
 from src.extractors.base import BaseExtractor
+from src.utils.image import is_valid_image_url
 
 # Archives disponibles : ajuster selon l'édition souhaitée
 _MEDIAEVAL_URLS = [
@@ -78,7 +79,7 @@ class MediaEvalExtractor(BaseExtractor):
         label_raw = str(raw.get("label") or "").lower().strip()
         date = str(raw.get("date") or raw.get("tweetDate") or "")
 
-        if not text or not image_url:
+        if not text or not is_valid_image_url(image_url):
             return None
 
         label = _LABEL_MAP.get(label_raw, "unknown")

--- a/src/extractors/mmfakebench.py
+++ b/src/extractors/mmfakebench.py
@@ -4,21 +4,27 @@ Pré-requis :
 - Avoir un compte HuggingFace et accepté le Data Usage Protocol sur :
   https://huggingface.co/datasets/liuxuannan/MMFakeBench
 - Définir HF_TOKEN dans .env
+
+Champs du dataset :
+  text, image_path, text_source, image_source, gt_answers, fake_cls
+
+Les images restent dans le repo HuggingFace — image_path est une référence
+interne accessible via load_dataset() au moment de l'entraînement.
 """
 
-import io
 import os
 import uuid
 from typing import Iterator
 
 from dotenv import load_dotenv
 
-from config import IMAGES_DIR, MMFAKEBENCH_DATASET_ID
+from config import MMFAKEBENCH_DATASET_ID
 from src.extractors.base import BaseExtractor
 
 load_dotenv()
 
-_LABEL_MAP = {0: "fake", 1: "real"}
+# gt_answers : "True" = contenu authentique, "False" = contenu manipulé
+_LABEL_MAP = {"True": "real", "False": "fake"}
 
 
 class MMFakeBenchExtractor(BaseExtractor):
@@ -50,57 +56,32 @@ class MMFakeBenchExtractor(BaseExtractor):
 
             for split_name, split in dataset.items():
                 self.logger.info("Config '%s' / split '%s' : %d entrées", config_name, split_name, len(split))
-                for row in split:
-                    yield dict(row)
+                yield from (dict(row) for row in split)
 
     def normalize(self, raw: dict) -> dict | None:
-        from PIL import Image
-
-        text = str(raw.get("text") or raw.get("caption") or "").strip()
-        title = str(raw.get("title") or "").strip()
-        raw_label = raw.get("label")
-
+        text = str(raw.get("text") or "").strip()
         if not text:
             return None
 
-        label = _LABEL_MAP.get(int(raw_label), "unknown") if raw_label is not None else "unknown"
-        entry_id = str(raw.get("id") or uuid.uuid4())
-
-        # L'image est un objet PIL intégré dans le dataset HF
-        pil_image = raw.get("image")
-        image_path = IMAGES_DIR / "mmfakebench" / f"{entry_id}.jpg"
-        image_url = str(raw.get("image_url") or "")
-
-        if pil_image is not None:
-            try:
-                image_path.parent.mkdir(parents=True, exist_ok=True)
-                if isinstance(pil_image, Image.Image):
-                    pil_image.convert("RGB").save(image_path, "JPEG")
-                else:
-                    return None
-            except Exception as e:
-                self.logger.debug("Erreur sauvegarde image %s : %s", entry_id, e)
-                return None
-        elif image_url:
-            from src.utils.image import download_image
-            if not download_image(image_url, image_path):
-                self.logger.debug("Image inaccessible, entrée ignorée : %s", image_url)
-                return None
-        else:
+        image_path = str(raw.get("image_path") or "").strip()
+        if not image_path:
             return None
 
+        raw_label = str(raw.get("gt_answers") or "").strip()
+        label = _LABEL_MAP.get(raw_label, "unknown")
+
         return {
-            "id": entry_id,
+            "id": str(uuid.uuid4()),
             "source": self.source_name,
-            "title": title,
+            "title": "",
             "text": text,
-            "image_url": image_url,
-            "image_path": str(image_path),
+            "image_url": "",
+            "image_path": image_path,
             "label": label,
             "label_confidence": "high",
             "language": "en",
-            "date": str(raw.get("date") or ""),
-            "url": str(raw.get("url") or ""),
-            "domain": str(raw.get("source") or ""),
+            "date": "",
+            "url": "",
+            "domain": str(raw.get("text_source") or ""),
             "extraction_method": "dataset",
         }

--- a/src/extractors/mmfakebench.py
+++ b/src/extractors/mmfakebench.py
@@ -20,6 +20,7 @@ from dotenv import load_dotenv
 
 from config import MMFAKEBENCH_DATASET_ID
 from src.extractors.base import BaseExtractor
+from src.utils.image import is_valid_image_url
 
 load_dotenv()
 

--- a/src/extractors/rss.py
+++ b/src/extractors/rss.py
@@ -8,6 +8,7 @@ import feedparser
 
 from config import RSS_FEEDS
 from src.extractors.base import BaseExtractor
+from src.utils.image import is_valid_image_url
 
 # Préfixes Snopes pour parser le label depuis le titre
 _SNOPES_LABEL_MAP = {
@@ -87,7 +88,7 @@ class RSSExtractor(BaseExtractor):
         date = raw.get("published", "") or raw.get("updated", "")
         image_url = _extract_image_url(raw)
 
-        if not text or not image_url:
+        if not text or not is_valid_image_url(image_url):
             return None
 
         # Label

--- a/src/extractors/rss.py
+++ b/src/extractors/rss.py
@@ -6,9 +6,8 @@ from urllib.parse import urlparse
 
 import feedparser
 
-from config import IMAGES_DIR, RSS_FEEDS
+from config import RSS_FEEDS
 from src.extractors.base import BaseExtractor
-from src.utils.image import download_image
 
 # Préfixes Snopes pour parser le label depuis le titre
 _SNOPES_LABEL_MAP = {
@@ -100,12 +99,6 @@ class RSSExtractor(BaseExtractor):
 
         domain = urlparse(url).netloc if url else ""
         entry_id = str(uuid.uuid4())
-        image_path = IMAGES_DIR / "rss" / f"{entry_id}.jpg"
-
-        success = download_image(image_url, image_path)
-        if not success:
-            self.logger.debug("Image inaccessible, entrée ignorée : %s", image_url)
-            return None
 
         return {
             "id": entry_id,
@@ -113,7 +106,7 @@ class RSSExtractor(BaseExtractor):
             "title": title,
             "text": text,
             "image_url": image_url,
-            "image_path": str(image_path),
+            "image_path": "",
             "label": label,
             "label_confidence": "medium",
             "language": feed_config.get("language", "en"),

--- a/src/utils/image.py
+++ b/src/utils/image.py
@@ -2,6 +2,7 @@
 
 import time
 from pathlib import Path
+from urllib.parse import urlparse
 
 import requests
 from PIL import Image, UnidentifiedImageError
@@ -58,6 +59,36 @@ def download_image(url: str, dest_path: Path, timeout: int = IMAGE_DOWNLOAD_TIME
             time.sleep(IMAGE_DOWNLOAD_BACKOFF ** attempt)
 
     return False
+
+
+_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".svg"}
+
+
+def is_valid_image_url(url: str) -> bool:
+    """
+    Vérifie qu'une URL pointe vers une image exploitable (format uniquement, sans réseau).
+
+    Critères :
+    - Schéma http ou https
+    - Extension de fichier image reconnue dans le chemin, OU absence d'extension
+      (CDNs et APIs servent souvent des images sans extension)
+    """
+    if not url or not isinstance(url, str):
+        return False
+    try:
+        parsed = urlparse(url.strip())
+    except Exception:
+        return False
+    if parsed.scheme not in ("http", "https"):
+        return False
+    if not parsed.netloc:
+        return False
+    path = parsed.path.lower()
+    if "." in path.split("/")[-1]:
+        ext = "." + path.rsplit(".", 1)[-1].split("?")[0]
+        if ext not in _IMAGE_EXTENSIONS:
+            return False
+    return True
 
 
 def validate_image(path: Path) -> bool:


### PR DESCRIPTION
## Summary

- **fix(mmfakebench)** : champs incorrects dans `normalize()` — `label` → `gt_answers`, `image` → `image_path`. Charge les deux configs `val` + `test` (11 000 entrées). Closes #5
- **refactor(extractors)** : suppression du téléchargement HTTP des images dans tous les extracteurs (`rss`, `fakeddit`, `mediaeval`, `hemt_fake`). `image_url` est conservé comme référence, `image_path` laissé vide.
- **feat(image)** : ajout de `is_valid_image_url()` dans `src/utils/image.py` — vérifie le format (schéma http/https + extension reconnue) sans réseau, conformément à la recommandation de la consigne étape 2.