### PR TITLE
feat(config): limites d'extraction par défaut par source

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,3 +32,12 @@ FAKEDDIT_RAW_DIR = RAW_DIR / "fakeddit"
 
 # Dataset HuggingFace MMFakeBench
 MMFAKEBENCH_DATASET_ID = "liuxuannan/MMFakeBench"
+
+# Limites d'extraction par défaut (None = pas de limite)
+DEFAULT_LIMITS: dict[str, int | None] = {
+    "mmfakebench": None,    # ~11 000 entrées, dataset annoté de qualité
+    "fakeddit":    10_000,  # dataset massif (>1M), sélection représentative
+    "hemt_fake":   None,    # taille raisonnable, annoté
+    "mediaeval":   None,    # ~1 000 entrées seulement
+    "rss":         500,     # flux live, qualité variable
+}

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from config import DEFAULT_LIMITS
 from src.utils.logger import get_logger
 
 logger = get_logger("main")
@@ -52,7 +53,8 @@ def main() -> None:
         type=int,
         default=None,
         metavar="N",
-        help="Nombre maximum d'entrées valides à extraire par source.",
+        help="Nombre maximum d'entrées valides à extraire (toutes sources). "
+             "Sans cette option, les limites par défaut de config.py s'appliquent.",
     )
     parser.add_argument(
         "--output",
@@ -68,9 +70,10 @@ def main() -> None:
     total_counters = {"total": 0, "success": 0, "skipped": 0, "errors": 0}
 
     for source in sources:
-        logger.info("=== Source : %s ===", source)
+        limit = args.limit if args.limit is not None else DEFAULT_LIMITS.get(source)
+        logger.info("=== Source : %s (limite : %s) ===", source, limit or "aucune")
         try:
-            counters = _run_source(source, args.output, args.limit)
+            counters = _run_source(source, args.output, limit)
             for k in total_counters:
                 total_counters[k] += counters.get(k, 0)
         except Exception as e:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,27 @@
+"""Tests pour config.py — DEFAULT_LIMITS."""
+
+from config import DEFAULT_LIMITS
+
+
+_KNOWN_SOURCES = {"mmfakebench", "fakeddit", "hemt_fake", "mediaeval", "rss"}
+
+
+def test_default_limits_covers_all_sources():
+    assert _KNOWN_SOURCES == set(DEFAULT_LIMITS.keys())
+
+
+def test_default_limits_values_are_none_or_positive_int():
+    for source, limit in DEFAULT_LIMITS.items():
+        assert limit is None or (isinstance(limit, int) and limit > 0), (
+            f"{source}: limite invalide ({limit!r})"
+        )
+
+
+def test_fakeddit_has_limit():
+    """Fakeddit est massif (>1M) — doit avoir une limite explicite."""
+    assert DEFAULT_LIMITS["fakeddit"] is not None
+
+
+def test_rss_has_limit():
+    """RSS est un flux live de qualité variable — doit avoir une limite explicite."""
+    assert DEFAULT_LIMITS["rss"] is not None

--- a/tests/test_extractors/test_fakeddit.py
+++ b/tests/test_extractors/test_fakeddit.py
@@ -1,8 +1,6 @@
 """Tests pour src/extractors/fakeddit.py."""
 
 import pytest
-from unittest.mock import patch
-import math
 
 from src.extractors.fakeddit import FakedditExtractor
 
@@ -26,41 +24,37 @@ def _make_raw(
     }
 
 
-def test_normalize_label_0_is_fake(tmp_path):
+def test_normalize_label_0_is_fake():
     extractor = FakedditExtractor()
     raw = _make_raw(label_2way=0)
-    with patch("src.extractors.fakeddit.download_image", return_value=True), \
-         patch("src.extractors.fakeddit.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
     assert result is not None
     assert result["label"] == "fake"
 
 
-def test_normalize_label_1_is_real(tmp_path):
+def test_normalize_label_1_is_real():
     extractor = FakedditExtractor()
     raw = _make_raw(label_2way=1, label_6way="true")
-    with patch("src.extractors.fakeddit.download_image", return_value=True), \
-         patch("src.extractors.fakeddit.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
     assert result is not None
     assert result["label"] == "real"
 
 
-def test_normalize_non_verifiable_returns_none(tmp_path):
+def test_normalize_non_verifiable_returns_none():
     extractor = FakedditExtractor()
     raw = _make_raw(label_6way="non-verifiable")
     result = extractor.normalize(raw)
     assert result is None
 
 
-def test_normalize_empty_image_url_returns_none(tmp_path):
+def test_normalize_empty_image_url_returns_none():
     extractor = FakedditExtractor()
     raw = _make_raw(image_url="")
     result = extractor.normalize(raw)
     assert result is None
 
 
-def test_normalize_nan_image_url_returns_none(tmp_path):
+def test_normalize_nan_image_url_returns_none():
     extractor = FakedditExtractor()
     raw = _make_raw()
     raw["image_url"] = float("nan")
@@ -68,28 +62,24 @@ def test_normalize_nan_image_url_returns_none(tmp_path):
     assert result is None
 
 
-def test_normalize_empty_title_returns_none(tmp_path):
+def test_normalize_empty_title_returns_none():
     extractor = FakedditExtractor()
     raw = _make_raw(title="")
     result = extractor.normalize(raw)
     assert result is None
 
 
-def test_normalize_image_download_fails_returns_none(tmp_path):
+def test_normalize_invalid_image_url_returns_none():
     extractor = FakedditExtractor()
-    raw = _make_raw()
-    with patch("src.extractors.fakeddit.download_image", return_value=False), \
-         patch("src.extractors.fakeddit.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    raw = _make_raw(image_url="not-a-url")
+    result = extractor.normalize(raw)
     assert result is None
 
 
-def test_normalize_output_schema(tmp_path):
+def test_normalize_output_schema():
     extractor = FakedditExtractor()
     raw = _make_raw()
-    with patch("src.extractors.fakeddit.download_image", return_value=True), \
-         patch("src.extractors.fakeddit.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
 
     assert result is not None
     expected_keys = {"id", "source", "title", "text", "image_url", "image_path",
@@ -100,3 +90,4 @@ def test_normalize_output_schema(tmp_path):
     assert result["extraction_method"] == "dataset"
     assert result["language"] == "en"
     assert result["label_confidence"] == "high"
+    assert result["image_path"] == ""

--- a/tests/test_extractors/test_hemt_fake.py
+++ b/tests/test_extractors/test_hemt_fake.py
@@ -1,7 +1,6 @@
 """Tests pour src/extractors/hemt_fake.py."""
 
 import pytest
-from unittest.mock import patch
 
 from src.extractors.hemt_fake import HemtFakeExtractor
 
@@ -35,56 +34,48 @@ def _make_raw(
     ("uncertain", "unknown"),
     ("", "unknown"),
 ])
-def test_normalize_label_mapping(label_raw, expected, tmp_path):
+def test_normalize_label_mapping(label_raw, expected):
     extractor = HemtFakeExtractor()
     raw = _make_raw(label=label_raw)
-    with patch("src.extractors.hemt_fake.download_image", return_value=True), \
-         patch("src.extractors.hemt_fake.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
     assert result is not None
     assert result["label"] == expected
 
 
-def test_normalize_missing_text_returns_none(tmp_path):
+def test_normalize_missing_text_returns_none():
     extractor = HemtFakeExtractor()
     raw = _make_raw(text="")
     result = extractor.normalize(raw)
     assert result is None
 
 
-def test_normalize_missing_image_url_returns_none(tmp_path):
+def test_normalize_missing_image_url_returns_none():
     extractor = HemtFakeExtractor()
     raw = _make_raw(image_url="")
     result = extractor.normalize(raw)
     assert result is None
 
 
-def test_normalize_image_download_fails_returns_none(tmp_path):
+def test_normalize_invalid_image_url_returns_none():
     extractor = HemtFakeExtractor()
-    raw = _make_raw()
-    with patch("src.extractors.hemt_fake.download_image", return_value=False), \
-         patch("src.extractors.hemt_fake.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    raw = _make_raw(image_url="not-a-valid-url")
+    result = extractor.normalize(raw)
     assert result is None
 
 
-def test_normalize_uses_content_field_as_text(tmp_path):
+def test_normalize_uses_content_field_as_text():
     extractor = HemtFakeExtractor()
     raw = _make_raw(text="")
     raw["content"] = "Content field text"
-    with patch("src.extractors.hemt_fake.download_image", return_value=True), \
-         patch("src.extractors.hemt_fake.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
     assert result is not None
     assert result["text"] == "Content field text"
 
 
-def test_normalize_output_schema(tmp_path):
+def test_normalize_output_schema():
     extractor = HemtFakeExtractor()
     raw = _make_raw()
-    with patch("src.extractors.hemt_fake.download_image", return_value=True), \
-         patch("src.extractors.hemt_fake.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
 
     assert result is not None
     expected_keys = {"id", "source", "title", "text", "image_url", "image_path",
@@ -93,3 +84,4 @@ def test_normalize_output_schema(tmp_path):
     assert expected_keys.issubset(result.keys())
     assert result["source"] == "hemt_fake"
     assert result["extraction_method"] == "dataset"
+    assert result["image_path"] == ""

--- a/tests/test_extractors/test_mediaeval.py
+++ b/tests/test_extractors/test_mediaeval.py
@@ -1,7 +1,6 @@
 """Tests pour src/extractors/mediaeval.py."""
 
 import pytest
-from unittest.mock import patch
 
 from src.extractors.mediaeval import MediaEvalExtractor
 
@@ -28,67 +27,57 @@ def _make_raw(
     ("non-verifiable", "unknown"),
     ("unknown_value", "unknown"),
 ])
-def test_normalize_label_mapping(label_raw, expected, tmp_path):
+def test_normalize_label_mapping(label_raw, expected):
     extractor = MediaEvalExtractor()
     raw = _make_raw(label=label_raw)
-    with patch("src.extractors.mediaeval.download_image", return_value=True), \
-         patch("src.extractors.mediaeval.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
     assert result is not None
     assert result["label"] == expected
 
 
-def test_normalize_missing_text_returns_none(tmp_path):
+def test_normalize_missing_text_returns_none():
     extractor = MediaEvalExtractor()
     raw = _make_raw(text="")
     result = extractor.normalize(raw)
     assert result is None
 
 
-def test_normalize_missing_image_url_returns_none(tmp_path):
+def test_normalize_missing_image_url_returns_none():
     extractor = MediaEvalExtractor()
     raw = _make_raw(image_url="")
     result = extractor.normalize(raw)
     assert result is None
 
 
-def test_normalize_image_download_fails_returns_none(tmp_path):
+def test_normalize_invalid_image_url_returns_none():
     extractor = MediaEvalExtractor()
-    raw = _make_raw()
-    with patch("src.extractors.mediaeval.download_image", return_value=False), \
-         patch("src.extractors.mediaeval.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    raw = _make_raw(image_url="ftp://bad-scheme.com/img.jpg")
+    result = extractor.normalize(raw)
     assert result is None
 
 
-def test_normalize_uses_text_field_fallback(tmp_path):
+def test_normalize_uses_text_field_fallback():
     extractor = MediaEvalExtractor()
     raw = _make_raw(text="")
     raw.pop("tweetText")
     raw["text"] = "Fallback text field"
-    with patch("src.extractors.mediaeval.download_image", return_value=True), \
-         patch("src.extractors.mediaeval.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
     assert result is not None
     assert result["text"] == "Fallback text field"
 
 
-def test_normalize_tweet_url_constructed(tmp_path):
+def test_normalize_tweet_url_constructed():
     extractor = MediaEvalExtractor()
     raw = _make_raw(tweet_id="987654321")
-    with patch("src.extractors.mediaeval.download_image", return_value=True), \
-         patch("src.extractors.mediaeval.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
     assert result is not None
     assert "987654321" in result["url"]
 
 
-def test_normalize_output_schema(tmp_path):
+def test_normalize_output_schema():
     extractor = MediaEvalExtractor()
     raw = _make_raw()
-    with patch("src.extractors.mediaeval.download_image", return_value=True), \
-         patch("src.extractors.mediaeval.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
 
     assert result is not None
     expected_keys = {"id", "source", "title", "text", "image_url", "image_path",
@@ -97,3 +86,4 @@ def test_normalize_output_schema(tmp_path):
     assert expected_keys.issubset(result.keys())
     assert result["source"] == "mediaeval"
     assert result["domain"] == "twitter.com"
+    assert result["image_path"] == ""

--- a/tests/test_extractors/test_rss.py
+++ b/tests/test_extractors/test_rss.py
@@ -1,7 +1,6 @@
 """Tests pour src/extractors/rss.py."""
 
 import pytest
-from unittest.mock import patch
 
 from src.extractors.rss import RSSExtractor, _parse_snopes_label, _extract_image_url
 
@@ -92,12 +91,10 @@ def _make_raw_rss(
     }
 
 
-def test_rss_normalize_valid_entry(tmp_path):
+def test_rss_normalize_valid_entry():
     extractor = RSSExtractor()
     raw = _make_raw_rss()
-    with patch("src.extractors.rss.download_image", return_value=True), \
-         patch("src.extractors.rss.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
 
     assert result is not None
     assert result["label"] == "real"
@@ -105,37 +102,34 @@ def test_rss_normalize_valid_entry(tmp_path):
     assert result["source"] == "rss"
     assert result["extraction_method"] == "rss"
     assert result["language"] == "en"
+    assert result["image_path"] == ""
 
 
-def test_rss_normalize_snopes_auto_label(tmp_path):
+def test_rss_normalize_snopes_auto_label():
     extractor = RSSExtractor()
     raw = _make_raw_rss(title="False: Ce vaccin est dangereux", label="auto")
-    with patch("src.extractors.rss.download_image", return_value=True), \
-         patch("src.extractors.rss.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    result = extractor.normalize(raw)
 
     assert result is not None
     assert result["label"] == "fake"
 
 
-def test_rss_normalize_no_text_returns_none(tmp_path):
+def test_rss_normalize_no_text_returns_none():
     extractor = RSSExtractor()
     raw = _make_raw_rss(text="")
     result = extractor.normalize(raw)
     assert result is None
 
 
-def test_rss_normalize_no_image_url_returns_none(tmp_path):
+def test_rss_normalize_no_image_url_returns_none():
     extractor = RSSExtractor()
     raw = _make_raw_rss(image_url="")
     result = extractor.normalize(raw)
     assert result is None
 
 
-def test_rss_normalize_image_download_fails_returns_none(tmp_path):
+def test_rss_normalize_invalid_image_url_returns_none():
     extractor = RSSExtractor()
-    raw = _make_raw_rss()
-    with patch("src.extractors.rss.download_image", return_value=False), \
-         patch("src.extractors.rss.IMAGES_DIR", tmp_path):
-        result = extractor.normalize(raw)
+    raw = _make_raw_rss(image_url="not-a-valid-url")
+    result = extractor.normalize(raw)
     assert result is None


### PR DESCRIPTION
## Summary
- Ajout de `DEFAULT_LIMITS` dans `config.py` : limites sensées par source pour un projet de formation
- `main.py` utilise ces limites si `--limit` n'est pas fourni en CLI
- `--limit N` reste prioritaire et écrase toutes les limites par défaut

| Source | Limite |
|---|---|
| mmfakebench | None (~11k) |
| fakeddit | 10 000 |
| hemt_fake | None |
| mediaeval | None (~1k) |
| rss | 500 |

- Intègre également le fix des tests obsolètes (patches `download_image`/`IMAGES_DIR` supprimés)
- Ajout de `tests/test_config.py` (4 tests vérifiant la cohérence de `DEFAULT_LIMITS`)

## Test plan
- [x] `uv run pytest tests/ -v` → **75 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)