### PR TITLE
feat(images): vérification format + accessibilité par source

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,25 @@ Pipeline Python modulaire qui transforme les données brutes (JSONL) en un datas
 |-------|-------------|
 | Nettoyage texte | Suppression HTML, normalisation espaces, caractères de contrôle |
 | Normalisation date | RFC 822 / ISO 8601 / UNIX → ISO 8601 unifié |
-| Validation image | `image_valid: bool` — format et schéma URL vérifiés |
+| Validation image | `image_valid: bool` — voir tableau ci-dessous |
 | Association texte-image | `text_image_ok: bool` — texte ET image présents ensemble |
 | Mapping labels | `label_int: int` — real=1, fake=0, unknown=-1 |
 | Enrichissement | `text_length`, `word_count`, `has_image` |
 | Déduplication | Hash MD5 sur (source + texte[:200]), première occurrence conservée |
+
+### Validation des images par source
+
+La stratégie de validation dépend du type de stockage de chaque source :
+
+| Source | Champ image | Vérification format | Vérification accessibilité |
+|--------|------------|--------------------|-----------------------------|
+| **Fakeddit** | `image_url` | ✅ `is_valid_image_url()` — schéma HTTP(S) + extension | Optionnelle — HEAD request si `IMAGE_CHECK_ACCESSIBLE=true` |
+| **RSS** | `image_url` | ✅ `is_valid_image_url()` — schéma HTTP(S) + extension | Optionnelle — HEAD request si `IMAGE_CHECK_ACCESSIBLE=true` |
+| **MiRAGeNews** | `image_path` | ✅ Garanti par la sauvegarde PIL | ✅ `validate_image()` — vérification Pillow du fichier local |
+| **MMFakeBench** | `image_path` | N/A — référence interne HuggingFace | N/A — pas de fichier local accessible |
+| **MediaEval VMU** | `image_path` | N/A — identifiant local (ZIP non téléchargé) | N/A — images non téléchargées |
+
+**Variable d'environnement** : `IMAGE_CHECK_ACCESSIBLE=true` active les HEAD requests pour les sources URL (Fakeddit, RSS). Désactivé par défaut — trop coûteux pour Fakeddit (~1M records).
 
 ### Architecture
 

--- a/config.py
+++ b/config.py
@@ -19,6 +19,13 @@ IMAGE_DOWNLOAD_TIMEOUT = 10       # secondes
 IMAGE_DOWNLOAD_RETRIES = 3        # tentatives max
 IMAGE_DOWNLOAD_BACKOFF = 2.0      # facteur de backoff exponentiel
 
+# Vérification d'accessibilité des URL d'images (HEAD request)
+# Désactivé par défaut : trop coûteux pour Fakeddit (~1M records).
+# Activer ponctuellement pour RSS ou en mode sampling.
+# Surcharger via variable d'environnement : IMAGE_CHECK_ACCESSIBLE=true
+import os as _os
+IMAGE_CHECK_ACCESSIBLE: bool = _os.getenv("IMAGE_CHECK_ACCESSIBLE", "false").lower() == "true"
+
 # Flux RSS (ajouter/supprimer une entrée pour modifier les sources)
 RSS_FEEDS = [
     {"url": "https://www.lemonde.fr/rss/une.xml",           "language": "fr", "label": "real"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,10 @@ dev = [
     "pytest-mock>=3.14",
     "responses>=0.25",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-mock>=3.15.1",
+    "responses>=0.26.0",
+]

--- a/src/transform/steps/validate_image.py
+++ b/src/transform/steps/validate_image.py
@@ -1,13 +1,23 @@
 """Validation des champs image d'un enregistrement."""
 
-from src.utils.image import is_valid_image_url
+from pathlib import Path
+
+from config import IMAGE_CHECK_ACCESSIBLE
+from src.utils.image import check_image_accessible, is_valid_image_url, validate_image
 
 
 def validate_image_fields(record: dict) -> dict:
     """Valide les champs image et ajoute le booléen `image_valid`.
 
-    Vérifie que `image_url` est une URL HTTP(S) avec extension image reconnue.
-    Le champ `image_path` (référence interne HF) est considéré valide s'il est non vide.
+    Stratégie par type de source :
+
+    - URL (fakeddit, rss) :
+        - Vérifie le format via `is_valid_image_url()`
+        - Si `IMAGE_CHECK_ACCESSIBLE=True`, vérifie l'accessibilité via HEAD request
+    - Fichier local (miragenews) :
+        - Vérifie l'intégrité via Pillow (`validate_image()`)
+    - Référence interne (mmfakebench, mediaeval) :
+        - Considéré valide si le champ est non vide (vérification réseau non applicable)
 
     Args:
         record: Enregistrement unifié issu des extracteurs.
@@ -17,12 +27,19 @@ def validate_image_fields(record: dict) -> dict:
     """
     image_url: str = record.get("image_url", "") or ""
     image_path: str = record.get("image_path", "") or ""
+    source: str = record.get("source", "") or ""
 
     if image_url:
         image_valid = is_valid_image_url(image_url)
+        if image_valid and IMAGE_CHECK_ACCESSIBLE:
+            image_valid = check_image_accessible(image_url)
     elif image_path:
-        # image_path est une référence interne HF (ex: "images/foo.jpg")
-        image_valid = bool(image_path.strip())
+        if source == "miragenews":
+            image_valid = validate_image(Path(image_path))
+        else:
+            # mmfakebench (référence interne HF) et mediaeval (identifiant local)
+            # — vérification réseau non applicable
+            image_valid = bool(image_path.strip())
     else:
         image_valid = False
 

--- a/src/utils/image.py
+++ b/src/utils/image.py
@@ -91,6 +91,28 @@ def is_valid_image_url(url: str) -> bool:
     return True
 
 
+def check_image_accessible(url: str, timeout: int = 5) -> bool:
+    """Vérifie qu'une URL d'image est accessible via HTTP HEAD.
+
+    Fait une requête HEAD (sans télécharger le contenu) et vérifie
+    que le statut HTTP est 2xx.
+
+    Args:
+        url: URL à tester.
+        timeout: Délai maximum en secondes (défaut : 5).
+
+    Returns:
+        True si l'URL répond avec un statut 2xx, False sinon.
+    """
+    headers = {"User-Agent": "Mozilla/5.0 (compatible; academic-research-bot/1.0)"}
+    try:
+        response = requests.head(url, timeout=timeout, headers=headers, allow_redirects=True)
+        return response.ok
+    except Exception as e:
+        logger.debug("Inaccessible : %s — %s", url, e)
+        return False
+
+
 def validate_image(path: Path) -> bool:
     """
     Vérifie qu'un fichier est une image valide et non corrompue via Pillow.

--- a/tests/test_transform/test_validate_image.py
+++ b/tests/test_transform/test_validate_image.py
@@ -1,5 +1,9 @@
 """Tests pour src/transform/steps/validate_image.py"""
 
+from unittest.mock import patch
+
+import pytest
+
 from src.transform.steps.validate_image import validate_image_fields
 
 
@@ -38,3 +42,53 @@ def test_original_fields_preserved():
     result = validate_image_fields(record)
     assert result["text"] == "hello"
     assert result["image_url"] == "https://example.com/img.png"
+
+
+def test_miragenews_valid_image_path(tmp_path, fake_image_bytes):
+    """image_path miragenews : appelle validate_image() sur le fichier local."""
+    img = tmp_path / "img.jpg"
+    img.write_bytes(fake_image_bytes)
+    record = {"image_url": "", "image_path": str(img), "source": "miragenews"}
+    result = validate_image_fields(record)
+    assert result["image_valid"] is True
+
+
+def test_miragenews_invalid_image_path(tmp_path):
+    """image_path miragenews : fichier corrompu → False."""
+    img = tmp_path / "bad.jpg"
+    img.write_bytes(b"not an image")
+    record = {"image_url": "", "image_path": str(img), "source": "miragenews"}
+    result = validate_image_fields(record)
+    assert result["image_valid"] is False
+
+
+def test_mmfakebench_path_trusted():
+    """image_path mmfakebench (ref interne HF) : non vide → True sans vérif fichier."""
+    record = {"image_url": "", "image_path": "images/foo.jpg", "source": "mmfakebench"}
+    result = validate_image_fields(record)
+    assert result["image_valid"] is True
+
+
+@patch("src.transform.steps.validate_image.IMAGE_CHECK_ACCESSIBLE", True)
+@patch("src.transform.steps.validate_image.check_image_accessible", return_value=True)
+def test_accessible_check_called_when_enabled(mock_check):
+    record = {"image_url": "https://example.com/photo.jpg", "image_path": ""}
+    result = validate_image_fields(record)
+    mock_check.assert_called_once_with("https://example.com/photo.jpg")
+    assert result["image_valid"] is True
+
+
+@patch("src.transform.steps.validate_image.IMAGE_CHECK_ACCESSIBLE", True)
+@patch("src.transform.steps.validate_image.check_image_accessible", return_value=False)
+def test_accessible_check_false_when_unreachable(mock_check):
+    record = {"image_url": "https://example.com/photo.jpg", "image_path": ""}
+    result = validate_image_fields(record)
+    assert result["image_valid"] is False
+
+
+@patch("src.transform.steps.validate_image.IMAGE_CHECK_ACCESSIBLE", False)
+@patch("src.transform.steps.validate_image.check_image_accessible")
+def test_accessible_check_not_called_when_disabled(mock_check):
+    record = {"image_url": "https://example.com/photo.jpg", "image_path": ""}
+    validate_image_fields(record)
+    mock_check.assert_not_called()

--- a/tests/test_utils/test_image.py
+++ b/tests/test_utils/test_image.py
@@ -3,7 +3,7 @@
 import pytest
 import responses as responses_lib
 
-from src.utils.image import download_image, validate_image
+from src.utils.image import check_image_accessible, download_image, validate_image
 
 
 IMAGE_URL = "https://example.com/photo.jpg"
@@ -68,3 +68,21 @@ def test_validate_image_invalid_file(tmp_path):
     path = tmp_path / "not_an_image.jpg"
     path.write_bytes(b"this is not an image")
     assert validate_image(path) is False
+
+
+@responses_lib.activate
+def test_check_image_accessible_200():
+    responses_lib.add(responses_lib.HEAD, IMAGE_URL, status=200)
+    assert check_image_accessible(IMAGE_URL) is True
+
+
+@responses_lib.activate
+def test_check_image_accessible_404():
+    responses_lib.add(responses_lib.HEAD, IMAGE_URL, status=404)
+    assert check_image_accessible(IMAGE_URL) is False
+
+
+@responses_lib.activate
+def test_check_image_accessible_connection_error():
+    responses_lib.add(responses_lib.HEAD, IMAGE_URL, body=Exception("timeout"))
+    assert check_image_accessible(IMAGE_URL) is False

--- a/uv.lock
+++ b/uv.lock
@@ -892,6 +892,13 @@ dev = [
     { name = "responses" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-mock" },
+    { name = "responses" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=46.0.5" },
@@ -910,6 +917,13 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "responses", specifier = ">=0.26.0" },
+]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Summary

- Ajout `check_image_accessible(url)` dans `src/utils/image.py` — HEAD request légère sans téléchargement
- `validate_image_fields()` : stratégie différenciée par source (URL → format + HEAD optionnel, miragenews → Pillow, mmfakebench/mediaeval → N/A)
- `IMAGE_CHECK_ACCESSIBLE` dans `config.py` — désactivé par défaut, activable via env var
- README : tableau de validation des images par source
- 21 tests (dont 9 nouveaux)

## Test plan

- [x] `uv run python -m pytest tests/test_utils/test_image.py tests/test_transform/test_validate_image.py -v` — 21/21 passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)