### PR TITLE
feat(extractors): typage fort ArticleRecord + ExtractionCounters

### DIFF
--- a/src/extractors/base.py
+++ b/src/extractors/base.py
@@ -2,8 +2,9 @@
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Iterator
+from typing import Any, Iterator, cast
 
+from src.extractors.types import ArticleRecord, ExtractionCounters
 from src.utils.io import write_jsonl
 from src.utils.logger import get_logger
 
@@ -26,7 +27,7 @@ class BaseExtractor(ABC):
         """Lit la source brute et yield chaque enregistrement brut."""
 
     @abstractmethod
-    def normalize(self, raw: dict) -> dict | None:
+    def normalize(self, raw: dict) -> ArticleRecord | None:
         """
         Convertit un enregistrement brut vers le schéma unifié.
 
@@ -34,15 +35,20 @@ class BaseExtractor(ABC):
         label invalide, image inaccessible…).
         """
 
-    def run(self, output_path: Path, limit: int | None = None) -> dict:
+    def run(self, output_path: Path, limit: int | None = None) -> ExtractionCounters:
         """
         Orchestre extract → normalize → save.
 
         Retourne un dict de compteurs : total, success, skipped, errors.
         """
         output_path = Path(output_path)
-        records: list[dict] = []
-        counters = {"total": 0, "success": 0, "skipped": 0, "errors": 0}
+        records: list[ArticleRecord] = []
+        counters: ExtractionCounters = {
+            "total": 0,
+            "success": 0,
+            "skipped": 0,
+            "errors": 0,
+        }
 
         self.logger.info("Démarrage extraction [%s]", self.source_name)
 
@@ -60,9 +66,11 @@ class BaseExtractor(ABC):
                     counters["success"] += 1
             except Exception as e:
                 counters["errors"] += 1
-                self.logger.debug("Erreur normalisation entrée #%d : %s", counters["total"], e)
+                self.logger.debug(
+                    "Erreur normalisation entrée #%d : %s", counters["total"], e
+                )
 
-        written = write_jsonl(records, output_path)
+        written = write_jsonl(cast(list[dict[str, Any]], records), output_path)
         self.logger.info(
             "[%s] Terminé — total=%d success=%d skipped=%d errors=%d → %s (%d lignes)",
             self.source_name,

--- a/src/extractors/fakeddit.py
+++ b/src/extractors/fakeddit.py
@@ -6,15 +6,16 @@ et les placer dans data/raw/fakeddit/ avant d'exécuter ce script.
 
 import uuid
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Literal
 
 import pandas as pd
 
 from config import FAKEDDIT_RAW_DIR
 from src.extractors.base import BaseExtractor
+from src.extractors.types import ArticleRecord
 from src.utils.image import is_valid_image_url
 
-_LABEL_MAP = {0: "fake", 1: "real"}
+_LABEL_MAP: dict[int, Literal["real", "fake", "unknown"]] = {0: "fake", 1: "real"}
 
 
 class FakedditExtractor(BaseExtractor):
@@ -40,7 +41,7 @@ class FakedditExtractor(BaseExtractor):
             except Exception as e:
                 self.logger.warning("Erreur lecture %s : %s", csv_path.name, e)
 
-    def normalize(self, raw: dict) -> dict | None:
+    def normalize(self, raw: dict) -> ArticleRecord | None:
         # Champs obligatoires
         image_url = raw.get("image_url", "")
         text = str(raw.get("title", "")).strip()

--- a/src/extractors/mediaeval.py
+++ b/src/extractors/mediaeval.py
@@ -19,12 +19,13 @@ Note : les images sont dans Mediaeval2016_TestSet_Images.zip (non téléchargé)
 import csv
 import io
 import uuid
-from typing import Iterator
+from typing import Iterator, Literal
 
 import requests
 
 from config import RAW_DIR
 from src.extractors.base import BaseExtractor
+from src.extractors.types import ArticleRecord
 
 _TESTSET_URL = (
     "https://raw.githubusercontent.com/MKLab-ITI/image-verification-corpus"
@@ -33,10 +34,10 @@ _TESTSET_URL = (
 _RAW_DIR = RAW_DIR / "mediaeval"
 _CACHE_FILE = _RAW_DIR / "mediaeval2016_testset_groundtruth.txt"
 
-_LABEL_MAP = {
-    "real":           "real",
-    "fake":           "fake",
-    "humor":          "fake",
+_LABEL_MAP: dict[str, Literal["real", "fake", "unknown"]] = {
+    "real": "real",
+    "fake": "fake",
+    "humor": "fake",
     "non-verifiable": "unknown",
 }
 
@@ -70,13 +71,13 @@ class MediaEvalExtractor(BaseExtractor):
         self.logger.info("%d entrées dans le testset", len(rows))
         yield from rows
 
-    def normalize(self, raw: dict) -> dict | None:
+    def normalize(self, raw: dict) -> ArticleRecord | None:
         text = str(raw.get("post_text") or "").strip()
         if not text:
             return None
 
-        post_id   = str(raw.get("post_id") or "").strip()
-        image_id  = str(raw.get("image_id") or "").strip()
+        post_id = str(raw.get("post_id") or "").strip()
+        image_id = str(raw.get("image_id") or "").strip()
         timestamp = str(raw.get("timestamp") or "").strip()
         label_raw = str(raw.get("label") or "").lower().strip()
 
@@ -90,7 +91,7 @@ class MediaEvalExtractor(BaseExtractor):
             "title": "",
             "text": text,
             "image_url": "",
-            "image_path": image_id,   # identifiant local (ex: "airstrikes_1")
+            "image_path": image_id,  # identifiant local (ex: "airstrikes_1")
             "label": label,
             "label_confidence": "high",
             "language": "en",

--- a/src/extractors/miragenews.py
+++ b/src/extractors/miragenews.py
@@ -23,6 +23,7 @@ from typing import Iterator
 
 from config import IMAGES_DIR
 from src.extractors.base import BaseExtractor
+from src.extractors.types import ArticleRecord
 
 _DATASET_ID = "anson-huang/mirage-news"
 _IMAGES_DIR = IMAGES_DIR / "miragenews"
@@ -58,14 +59,16 @@ class MiRAGeNewsExtractor(BaseExtractor):
                     trust_remote_code=False,
                 )
             except Exception as e:
-                self.logger.warning("Impossible de charger le split '%s' : %s", split_name, e)
+                self.logger.warning(
+                    "Impossible de charger le split '%s' : %s", split_name, e
+                )
                 continue
 
             self.logger.info("Split '%s' : %d entrées", split_name, len(split))
             for row in split:
-                yield {"_split": split_name, **row}
+                yield {"_split": split_name, **dict(row)}
 
-    def normalize(self, raw: dict) -> dict | None:
+    def normalize(self, raw: dict) -> ArticleRecord | None:
         text = str(raw.get("text") or "").strip()
         if not text:
             return None

--- a/src/extractors/mmfakebench.py
+++ b/src/extractors/mmfakebench.py
@@ -14,19 +14,20 @@ interne accessible via load_dataset() au moment de l'entraînement.
 
 import os
 import uuid
-from typing import Iterator
+from typing import Iterator, Literal
 
 from dotenv import load_dotenv
 
 from config import MMFAKEBENCH_DATASET_ID
 from src.extractors.base import BaseExtractor
+from src.extractors.types import ArticleRecord
 from src.utils.image import is_valid_image_url
 
 load_dotenv()
 
 # gt_answers : "True" = contenu authentique, "Fake" = contenu manipulé
 # (valeurs réelles observées dans le dataset, pas "False")
-_LABEL_MAP = {"True": "real", "Fake": "fake", "False": "fake"}
+_LABEL_MAP: dict[str, Literal["real", "fake", "unknown"]] = {"True": "real", "Fake": "fake", "False": "fake"}
 
 
 class MMFakeBenchExtractor(BaseExtractor):
@@ -60,7 +61,7 @@ class MMFakeBenchExtractor(BaseExtractor):
                 self.logger.info("Config '%s' / split '%s' : %d entrées", config_name, split_name, len(split))
                 yield from (dict(row) for row in split)
 
-    def normalize(self, raw: dict) -> dict | None:
+    def normalize(self, raw: dict) -> ArticleRecord | None:
         text = str(raw.get("text") or "").strip()
         if not text:
             return None

--- a/src/extractors/rss.py
+++ b/src/extractors/rss.py
@@ -1,17 +1,18 @@
 """Extracteur RSS — flux publics de sources fiables."""
 
 import uuid
-from typing import Iterator
+from typing import Iterator, Literal
 from urllib.parse import urlparse
 
 import feedparser
 
 from config import RSS_FEEDS
 from src.extractors.base import BaseExtractor
+from src.extractors.types import ArticleRecord
 from src.utils.image import is_valid_image_url
 
 # Préfixes Snopes pour parser le label depuis le titre
-_SNOPES_LABEL_MAP = {
+_SNOPES_LABEL_MAP: dict[str, Literal["real", "fake", "unknown"]] = {
     "true:": "real",
     "false:": "fake",
     "mostly true:": "real",
@@ -25,7 +26,7 @@ _SNOPES_LABEL_MAP = {
 }
 
 
-def _parse_snopes_label(title: str) -> str:
+def _parse_snopes_label(title: str) -> Literal["real", "fake", "unknown"]:
     """Extrait le label depuis un titre Snopes. Retourne 'unknown' si non reconnu."""
     lower = title.lower()
     for prefix, label in _SNOPES_LABEL_MAP.items():
@@ -80,7 +81,7 @@ class RSSExtractor(BaseExtractor):
             except Exception as e:
                 self.logger.warning("Erreur lecture flux %s : %s", url, e)
 
-    def normalize(self, raw: dict) -> dict | None:
+    def normalize(self, raw: dict) -> ArticleRecord | None:
         feed_config = raw.get("_feed_config", {})
         title = raw.get("title", "").strip()
         text = raw.get("summary", "").strip()

--- a/src/extractors/types.py
+++ b/src/extractors/types.py
@@ -1,0 +1,30 @@
+"""Types partagés entre tous les extracteurs."""
+
+from typing import Literal, TypedDict
+
+
+class ArticleRecord(TypedDict):
+    """Schéma unifié retourné par chaque extracteur via normalize()."""
+
+    id: str
+    source: str
+    title: str
+    text: str
+    image_url: str
+    image_path: str
+    label: Literal["real", "fake", "unknown"]
+    label_confidence: Literal["high", "medium", "low"]
+    language: str
+    date: str
+    url: str
+    domain: str
+    extraction_method: Literal["dataset", "rss"]
+
+
+class ExtractionCounters(TypedDict):
+    """Compteurs retournés par BaseExtractor.run()."""
+
+    total: int
+    success: int
+    skipped: int
+    errors: int

--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -2,10 +2,10 @@
 
 import json
 from pathlib import Path
-from typing import Iterator
+from typing import Any, Iterator, Sequence
 
 
-def write_jsonl(records: list[dict], path: Path) -> int:
+def write_jsonl(records: Sequence[dict[str, Any]], path: Path) -> int:
     """Écrit une liste de dicts en JSON Lines. Retourne le nombre d'entrées écrites."""
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_extractors/test_base.py
+++ b/tests/test_extractors/test_base.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Iterator
 
 from src.extractors.base import BaseExtractor
+from src.extractors.types import ArticleRecord, ExtractionCounters
 from src.utils.io import read_jsonl
 
 
@@ -21,14 +22,28 @@ class _FakeExtractor(BaseExtractor):
     def extract(self) -> Iterator[dict]:
         yield from self._raw_items
 
-    def normalize(self, raw: dict) -> dict | None:
+    def normalize(self, raw: dict) -> ArticleRecord | None:
         if self._normalize_fn is not None:
             return self._normalize_fn(raw)
-        return raw
+        return raw  # type: ignore[return-value]
 
 
-def _valid_record(i: int) -> dict:
-    return {"id": str(i), "text": f"text {i}", "label": "real"}
+def _valid_record(i: int) -> ArticleRecord:
+    return {
+        "id": str(i),
+        "source": "test",
+        "title": f"title {i}",
+        "text": f"text {i}",
+        "image_url": "",
+        "image_path": "",
+        "label": "real",
+        "label_confidence": "high",
+        "language": "en",
+        "date": "",
+        "url": "",
+        "domain": "",
+        "extraction_method": "dataset",
+    }
 
 
 def test_run_all_valid(tmp_path):
@@ -118,4 +133,12 @@ def test_run_returns_dict_with_all_keys(tmp_path):
     extractor = _FakeExtractor([])
     output = tmp_path / "out.jsonl"
     counters = extractor.run(output)
-    assert set(counters.keys()) == {"total", "success", "skipped", "errors"}
+    assert set(counters.keys()) == set(ExtractionCounters.__annotations__.keys())
+
+
+def test_run_counters_are_int(tmp_path):
+    items = [_valid_record(i) for i in range(3)]
+    extractor = _FakeExtractor(items)
+    counters = extractor.run(tmp_path / "out.jsonl")
+    for key, value in counters.items():
+        assert isinstance(value, int), f"compteur '{key}' doit être int"

--- a/tests/test_extractors/test_fakeddit.py
+++ b/tests/test_extractors/test_fakeddit.py
@@ -3,6 +3,9 @@
 import pytest
 
 from src.extractors.fakeddit import FakedditExtractor
+from src.extractors.types import ArticleRecord
+
+_ARTICLE_KEYS = set(ArticleRecord.__annotations__.keys())
 
 
 def _make_raw(
@@ -82,12 +85,10 @@ def test_normalize_output_schema():
     result = extractor.normalize(raw)
 
     assert result is not None
-    expected_keys = {"id", "source", "title", "text", "image_url", "image_path",
-                     "label", "label_confidence", "language", "date", "url", "domain",
-                     "extraction_method"}
-    assert expected_keys.issubset(result.keys())
+    assert set(result.keys()) == _ARTICLE_KEYS
     assert result["source"] == "fakeddit"
     assert result["extraction_method"] == "dataset"
     assert result["language"] == "en"
     assert result["label_confidence"] == "high"
     assert result["image_path"] == ""
+    assert result["label"] in {"real", "fake", "unknown"}

--- a/tests/test_extractors/test_mediaeval.py
+++ b/tests/test_extractors/test_mediaeval.py
@@ -7,6 +7,9 @@ Format TSV réel (MKLab-ITI/image-verification-corpus) :
 import pytest
 
 from src.extractors.mediaeval import MediaEvalExtractor
+from src.extractors.types import ArticleRecord
+
+_ARTICLE_KEYS = set(ArticleRecord.__annotations__.keys())
 
 
 def _make_raw(
@@ -80,10 +83,8 @@ def test_normalize_output_schema():
     result = extractor.normalize(raw)
 
     assert result is not None
-    expected_keys = {"id", "source", "title", "text", "image_url", "image_path",
-                     "label", "label_confidence", "language", "date", "url", "domain",
-                     "extraction_method"}
-    assert expected_keys.issubset(result.keys())
+    assert set(result.keys()) == _ARTICLE_KEYS
     assert result["source"] == "mediaeval"
     assert result["domain"] == "twitter.com"
     assert result["image_path"] == "airstrikes_1"
+    assert result["label"] in {"real", "fake", "unknown"}

--- a/tests/test_extractors/test_miragenews.py
+++ b/tests/test_extractors/test_miragenews.py
@@ -12,6 +12,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.extractors.miragenews import MiRAGeNewsExtractor
+from src.extractors.types import ArticleRecord
+
+_ARTICLE_KEYS = set(ArticleRecord.__annotations__.keys())
 
 
 def _make_pil_image():
@@ -91,10 +94,8 @@ def test_normalize_output_schema(tmp_path):
         result = extractor.normalize(raw)
 
     assert result is not None
-    expected_keys = {"id", "source", "title", "text", "image_url", "image_path",
-                     "label", "label_confidence", "language", "date", "url", "domain",
-                     "extraction_method"}
-    assert expected_keys.issubset(result.keys())
+    assert set(result.keys()) == _ARTICLE_KEYS
     assert result["source"] == "miragenews"
     assert result["language"] == "en"
     assert result["extraction_method"] == "dataset"
+    assert result["label"] in {"real", "fake", "unknown"}

--- a/tests/test_extractors/test_rss.py
+++ b/tests/test_extractors/test_rss.py
@@ -3,6 +3,9 @@
 import pytest
 
 from src.extractors.rss import RSSExtractor, _parse_snopes_label, _extract_image_url
+from src.extractors.types import ArticleRecord
+
+_ARTICLE_KEYS = set(ArticleRecord.__annotations__.keys())
 
 
 # --- _parse_snopes_label ---
@@ -97,12 +100,14 @@ def test_rss_normalize_valid_entry():
     result = extractor.normalize(raw)
 
     assert result is not None
+    assert set(result.keys()) == _ARTICLE_KEYS
     assert result["label"] == "real"
     assert result["text"] == "Sample article text"
     assert result["source"] == "rss"
     assert result["extraction_method"] == "rss"
     assert result["language"] == "en"
     assert result["image_path"] == ""
+    assert result["label"] in {"real", "fake", "unknown"}
 
 
 def test_rss_normalize_snopes_auto_label():

--- a/tests/test_extractors/test_types.py
+++ b/tests/test_extractors/test_types.py
@@ -1,0 +1,87 @@
+"""Tests pour src/extractors/types.py — ArticleRecord et ExtractionCounters."""
+
+from src.extractors.types import ArticleRecord, ExtractionCounters
+
+ARTICLE_KEYS = set(ArticleRecord.__annotations__.keys())
+COUNTER_KEYS = set(ExtractionCounters.__annotations__.keys())
+
+VALID_LABELS = {"real", "fake", "unknown"}
+VALID_CONFIDENCES = {"high", "medium", "low"}
+VALID_EXTRACTION_METHODS = {"dataset", "rss"}
+
+
+def _make_article(**overrides) -> ArticleRecord:
+    base: ArticleRecord = {
+        "id": "abc123",
+        "source": "fakeddit",
+        "title": "Test title",
+        "text": "Test text",
+        "image_url": "https://example.com/img.jpg",
+        "image_path": "",
+        "label": "real",
+        "label_confidence": "high",
+        "language": "en",
+        "date": "2024-01-01",
+        "url": "https://example.com",
+        "domain": "example.com",
+        "extraction_method": "dataset",
+    }
+    base.update(overrides)  # type: ignore[typeddict-item]
+    return base
+
+
+# ── ArticleRecord ──────────────────────────────────────────────────────────────
+
+def test_article_record_has_13_keys():
+    assert len(ARTICLE_KEYS) == 13
+
+
+def test_article_record_required_keys():
+    expected = {
+        "id", "source", "title", "text", "image_url", "image_path",
+        "label", "label_confidence", "language", "date", "url",
+        "domain", "extraction_method",
+    }
+    assert ARTICLE_KEYS == expected
+
+
+def test_article_record_valid_label_values():
+    for label in VALID_LABELS:
+        record = _make_article(label=label)
+        assert record["label"] == label
+
+
+def test_article_record_valid_confidence_values():
+    for conf in VALID_CONFIDENCES:
+        record = _make_article(label_confidence=conf)
+        assert record["label_confidence"] == conf
+
+
+def test_article_record_valid_extraction_methods():
+    for method in VALID_EXTRACTION_METHODS:
+        record = _make_article(extraction_method=method)
+        assert record["extraction_method"] == method
+
+
+def test_article_record_all_fields_are_str():
+    record = _make_article()
+    for key, value in record.items():
+        assert isinstance(value, str), f"Champ '{key}' doit être str, got {type(value)}"
+
+
+# ── ExtractionCounters ────────────────────────────────────────────────────────
+
+def test_extraction_counters_has_4_keys():
+    assert len(COUNTER_KEYS) == 4
+
+
+def test_extraction_counters_required_keys():
+    assert COUNTER_KEYS == {"total", "success", "skipped", "errors"}
+
+
+def test_extraction_counters_values_are_int():
+    counters: ExtractionCounters = {
+        "total": 10, "success": 8, "skipped": 1, "errors": 1
+    }
+    for key, value in counters.items():
+        assert isinstance(value, int), f"Compteur '{key}' doit être int"


### PR DESCRIPTION
## Summary

- Nouveau `src/extractors/types.py` : `ArticleRecord` (TypedDict, 13 champs, `Literal` pour `label`/`label_confidence`/`extraction_method`) et `ExtractionCounters`
- `BaseExtractor` : `normalize()` → `ArticleRecord | None`, `run()` → `ExtractionCounters`
- 5 extracteurs : `_LABEL_MAP` typés `Literal`, signatures mises à jour
- `write_jsonl` : `Sequence[dict[str, Any]]` (covariant, compatible TypedDict)
- +10 tests (`test_types.py`, mise à jour schemas DRY via `ArticleRecord.__annotations__`)

## Test plan

- [x] `uv run pytest` — 147/147 passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)