### PR TITLE
feat(monitoring): alertes email Mailjet sur échec DAG

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,10 @@ DATA_POSTGRES_PASSWORD=
 # URL de connexion au data warehouse ETL (utilisée par le dashboard et l'exporter)
 # Format : postgresql+psycopg2://<user>:<DATA_POSTGRES_PASSWORD>@localhost/<db>
 DATA_POSTGRES_URL=postgresql+psycopg2://etl_user:<DATA_POSTGRES_PASSWORD>@localhost/multimodal
+
+# Alertes email Airflow via Mailjet
+# Créer un compte sur https://app.mailjet.com → SMTP Settings → récupérer API Key + Secret Key
+MAILJET_API_KEY=
+MAILJET_SECRET_KEY=
+MAILJET_SENDER_EMAIL=
+AIRFLOW_ALERT_EMAIL=

--- a/README.md
+++ b/README.md
@@ -180,21 +180,22 @@ src/load/
 ```
 extract_rss ────────┐
 extract_fakeddit ───┤
-extract_mmfakebench ┼──► transform_data ──► load_to_postgres
+extract_mmfakebench ┼──► transform_data ──► load_to_postgres ──► export_metrics
 extract_miragenews ─┤
 extract_mediaeval ──┘
 ```
 
-Toutes les tâches extract sont parallèles. Le DAG est déclenché manuellement depuis l'UI.
+Toutes les tâches extract sont parallèles. `export_metrics` enregistre les KPI du run dans la table `pipeline_runs` (durée, volumes, taux d'erreur). Le DAG est déclenché manuellement depuis l'UI.
 
 ### Démarrage
 
 **Prérequis** : Docker Desktop installé et démarré.
 
 ```bash
-# 1. Renseigner les 3 variables du .env
+# 1. Copier et renseigner le .env
 cp .env.example .env
-# Éditer HF_TOKEN, AIRFLOW_POSTGRES_PASSWORD, DATA_POSTGRES_PASSWORD
+# Éditer : HF_TOKEN, AIRFLOW_POSTGRES_PASSWORD, DATA_POSTGRES_PASSWORD
+# Optionnel : MAILJET_* pour les alertes email (voir ci-dessous)
 
 # 2. Générer les clés crypto (une seule fois)
 make airflow-keygen
@@ -214,15 +215,30 @@ make airflow-down
 
 ### Variables d'environnement (`.env`)
 
-Seules 3 variables sont à renseigner manuellement :
+| Variable | Obligatoire | Description |
+|----------|-------------|-------------|
+| `HF_TOKEN` | ✅ | Token HuggingFace (requis pour MMFakeBench et MirageNews) |
+| `AIRFLOW_POSTGRES_PASSWORD` | ✅ | Mot de passe PostgreSQL interne Airflow |
+| `DATA_POSTGRES_PASSWORD` | ✅ | Mot de passe du data warehouse ETL |
+| `DATA_POSTGRES_URL` | ✅ | URL de connexion au data warehouse (dashboard + exporter) |
+| `MAILJET_API_KEY` | ⬜ | Clé API Mailjet (alertes email sur échec) |
+| `MAILJET_SECRET_KEY` | ⬜ | Clé secrète Mailjet |
+| `MAILJET_SENDER_EMAIL` | ⬜ | Expéditeur vérifié sur Mailjet |
+| `AIRFLOW_ALERT_EMAIL` | ⬜ | Destinataire des alertes email |
 
-| Variable | Description |
-|----------|-------------|
-| `HF_TOKEN` | Token HuggingFace (requis pour MMFakeBench) |
-| `AIRFLOW_POSTGRES_PASSWORD` | Mot de passe PostgreSQL interne Airflow |
-| `DATA_POSTGRES_PASSWORD` | Mot de passe du data warehouse ETL |
+Les clés crypto (`AIRFLOW__CORE__FERNET_KEY`, `AIRFLOW_SECRET_KEY`) sont générées automatiquement par `make airflow-keygen`.
 
-Les clés crypto (`AIRFLOW__CORE__FERNET_KEY`, `AIRFLOW_SECRET_KEY`) sont générées et ajoutées automatiquement dans `.env` par `make airflow-keygen`.
+### Alertes email (Mailjet)
+
+En cas d'échec d'une tâche du DAG, Airflow peut envoyer un email automatiquement via Mailjet (6 000 emails/mois gratuits).
+
+**Configuration :**
+1. Créer un compte sur [app.mailjet.com](https://app.mailjet.com/account/smtp)
+2. Récupérer l'API Key et la Secret Key depuis *SMTP Settings*
+3. Renseigner les 4 variables `MAILJET_*` et `AIRFLOW_ALERT_EMAIL` dans `.env`
+4. Relancer : `make airflow-down && make airflow-up`
+
+> Sans ces variables, le pipeline fonctionne normalement — les alertes email sont simplement désactivées.
 
 ### Sécurité
 

--- a/dags/etl_multimodal.py
+++ b/dags/etl_multimodal.py
@@ -12,8 +12,10 @@ Chaque tâche d'extraction appelle directement l'extracteur correspondant
 réutilise run_pipeline() de l'étape 3. La tâche export_metrics insère les
 statistiques de run dans la table pipeline_runs (étape 5).
 """
+
 from __future__ import annotations
 
+import os
 import time
 from datetime import datetime
 
@@ -24,9 +26,11 @@ from airflow.operators.python import PythonOperator
 # Callables des tâches
 # ---------------------------------------------------------------------------
 
+
 def _extract_source(source_name: str, **context) -> dict:
     """Extrait une source et retourne les stats via XCom."""
     import sys
+
     sys.path.insert(0, "/opt/airflow")
 
     from main import EXTRACTORS
@@ -45,8 +49,8 @@ def _extract_source(source_name: str, **context) -> dict:
     # Limites spécifiques au DAG : on plafonne les sources volumineuses
     # pour garder un run ETL < 10 min (l'extraction complète se fait via make extract)
     DAG_LIMITS: dict[str, int | None] = {
-        "miragenews": 500,   # ~15 000 entrées → trop long via Docker volume
-        "fakeddit":   2_000,
+        "miragenews": 500,  # ~15 000 entrées → trop long via Docker volume
+        "fakeddit": 2_000,
     }
     default_limit = DEFAULT_LIMITS.get(source_name)
     limit = DAG_LIMITS.get(source_name, default_limit)
@@ -60,6 +64,7 @@ def _extract_source(source_name: str, **context) -> dict:
 def _transform(**context) -> dict:
     """Transforme tous les JSONL extraits → Parquet."""
     import sys
+
     sys.path.insert(0, "/opt/airflow")
 
     from src.transform.pipeline import run_pipeline
@@ -73,6 +78,7 @@ def _transform(**context) -> dict:
 def _load(**context) -> dict:
     """Charge le Parquet transformé dans PostgreSQL."""
     import sys
+
     sys.path.insert(0, "/opt/airflow")
 
     from src.load.postgres_loader import load_parquet_to_postgres
@@ -86,6 +92,7 @@ def _load(**context) -> dict:
 def _export_metrics(**context) -> None:
     """Collecte les XCom de toutes les tâches et insère dans pipeline_runs."""
     import sys
+
     sys.path.insert(0, "/opt/airflow")
 
     from src.metrics.exporter import insert_run_metrics
@@ -121,11 +128,17 @@ def _export_metrics(**context) -> None:
 with DAG(
     dag_id="etl_multimodal",
     description="ETL multimodal : extraction → transformation → chargement PostgreSQL → métriques",
-    schedule=None,           # Déclenchement manuel depuis l'UI
+    schedule=None,  # Déclenchement manuel depuis l'UI
     start_date=datetime(2025, 1, 1),
     catchup=False,
     tags=["etl", "multimodal"],
-    default_args={"retries": 1},
+    default_args={
+        "retries": 1,
+        "retry_delay": 30,  # 30s pour la démo
+        "email": [os.environ.get("AIRFLOW_ALERT_EMAIL", "")],
+        "email_on_failure": True,
+        "email_on_retry": False,
+    },
 ) as dag:
 
     sources = ["rss", "fakeddit", "mmfakebench", "miragenews", "mediaeval"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,13 @@ x-airflow-common: &airflow-common
     PYTHONPATH: /opt/airflow
     DATA_POSTGRES_URL: postgresql+psycopg2://etl_user:${DATA_POSTGRES_PASSWORD}@data-postgres/multimodal
     HF_TOKEN: ${HF_TOKEN}
+    AIRFLOW__SMTP__SMTP_HOST: in-v3.mailjet.com
+    AIRFLOW__SMTP__SMTP_PORT: "587"
+    AIRFLOW__SMTP__SMTP_USER: ${MAILJET_API_KEY}
+    AIRFLOW__SMTP__SMTP_PASSWORD: ${MAILJET_SECRET_KEY}
+    AIRFLOW__SMTP__SMTP_MAIL_FROM: ${MAILJET_SENDER_EMAIL}
+    AIRFLOW__SMTP__SMTP_SSL: "False"
+    AIRFLOW__SMTP__SMTP_STARTTLS: "True"
   volumes:
     - ./dags:/opt/airflow/dags
     - ./src:/opt/airflow/src


### PR DESCRIPTION
## Summary

- `docker-compose.yaml` : 7 variables SMTP Mailjet dans `x-airflow-common` (référencées depuis `.env`)
- `dags/etl_multimodal.py` : `email_on_failure=True`, destinataire via `AIRFLOW_ALERT_EMAIL`
- `.env.example` : variables `MAILJET_API_KEY`, `MAILJET_SECRET_KEY`, `MAILJET_SENDER_EMAIL`, `AIRFLOW_ALERT_EMAIL`
- `README` : tableau complet des variables `.env` + section dédiée Mailjet avec instructions

## Test plan

- [x] Testé en conditions réelles : arrêt `data-postgres` → tâche `load_to_postgres` FAILED → email reçu

🤖 Generated with [Claude Code](https://claude.com/claude-code)